### PR TITLE
[Finish]退会済みユーザーのログイン時は会員登録画面へ遷移するよう実装

### DIFF
--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  before_action :user_state, only: [:create]
 
   def after_sign_in_path_for(resource)
     todos_path
@@ -26,7 +27,21 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  # protected
+  protected
+
+  # 退会済みユーザーがログインしようとした場合は新規登録画面へ遷移させるアクション
+  def user_state
+    # まずはメアドからアカウントを取得する(find_by)
+    @user = User.find_by(email: params[:user][:email])
+    
+    # メアドからアカウントを取得できなければ、このメソッドを終了
+    return if !@user
+
+    # アカウントが存在し、且つそのアカウントの退会フラグがtrueの場合
+    if @user.valid_password?(params[:user][:password]) && @user.is_deleted == true
+      redirect_to new_user_registration_path
+    end
+  end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params


### PR DESCRIPTION
ユーザーログイン時の処理の分岐を実装しました
{
・coutrollers/public/users/sessions_controllerにて、
ユーザーが退会している場合、新規登録画面へ遷移するよう分岐を実装
}